### PR TITLE
Added client scope validation for sending notification

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.html
@@ -13,8 +13,10 @@
     </mat-checkbox>
     <div class="tb-hint" style="padding-bottom: 16px;" translate>tb.rulenode.notify-device-hint</div>
   </div>
-  <mat-checkbox formControlName="sendAttributesUpdatedNotification" style="padding-bottom: 8px;">
-    {{ 'tb.rulenode.send-attributes-updated-notification' | translate }}
-  </mat-checkbox>
-  <div class="tb-hint" [innerHTML]="'tb.rulenode.send-attributes-updated-notification-hint' | translate | safeHtml"></div>
+  <div *ngIf="attributesConfigForm.get('scope').value !== 'CLIENT_SCOPE'">
+    <mat-checkbox formControlName="sendAttributesUpdatedNotification" style="padding-bottom: 8px;">
+      {{ 'tb.rulenode.send-attributes-updated-notification' | translate }}
+    </mat-checkbox>
+    <div class="tb-hint" [innerHTML]="'tb.rulenode.send-attributes-updated-notification-hint' | translate | safeHtml"></div>
+  </div>
 </section>

--- a/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.ts
@@ -31,6 +31,11 @@ export class AttributesConfigComponent extends RuleNodeConfigurationComponent {
       notifyDevice: [configuration ? configuration.notifyDevice : true, []],
       sendAttributesUpdatedNotification: [configuration ? configuration.sendAttributesUpdatedNotification : false, []]
     });
+    this.attributesConfigForm.get('scope').valueChanges.subscribe((value) => {
+      if (value === 'CLIENT_SCOPE') {
+        this.attributesConfigForm.get('sendAttributesUpdatedNotification').patchValue(false, {emitEvent: false});
+      }
+    })
   }
 
 }

--- a/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/action/attributes-config.component.ts
@@ -35,7 +35,7 @@ export class AttributesConfigComponent extends RuleNodeConfigurationComponent {
       if (value === 'CLIENT_SCOPE') {
         this.attributesConfigForm.get('sendAttributesUpdatedNotification').patchValue(false, {emitEvent: false});
       }
-    })
+    });
   }
 
 }


### PR DESCRIPTION
UI example:

SHARED_SCOPE:

![image](https://user-images.githubusercontent.com/16356590/203765032-11b96649-481d-4732-a988-dc9bcc6f6f54.png)
CLIENT_SCOPE:

![image](https://user-images.githubusercontent.com/16356590/203764974-5a3786e9-ce52-4390-a02a-7fd18303380d.png)

SERVER_SCOPE:

![image](https://user-images.githubusercontent.com/16356590/203764940-3799ab83-9a37-45e2-aaae-f9f3feb455ff.png)

